### PR TITLE
PKGBUILD: support drop-in patches from "custom" directory

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -51,6 +51,12 @@ prepare() {
   echo "-${pkgrel}" > localversion.40-pkgrel
   echo '-aarch64-rk3588-bsp5.10' > localversion.50-pkgname
 
+  # this is only for local builds so there is no need to integrity check. (if needed)
+  for p in ../../custom/*.patch; do
+    echo "Custom Patching with ${p}"
+    patch -p1 -N -i $p || true
+  done
+
   echo "Updating config file..."
   cat "../orangepi-build/${_config}" > '.config'
   make olddefconfig


### PR DESCRIPTION
Related to https://github.com/7Ji-PKGBUILDs/.meta/issues/31

For easier patching and testing of local kernel builds, support drop-in patches that user can put in "custom" directory near the PKGBUILD file.

It aligns with how this is done in e.g. linux-aarch64-rockchip-bsp5.10-joshua PKGBUILD: https://github.com/7Ji-PKGBUILDs/linux-aarch64-rockchip-bsp5.10-joshua/blob/3c831c2fe003f371a1bf967f2410664d4b1c0ac9/PKGBUILD#L35