### PR TITLE
Patch against rockchip vop2 & rga bugs and add support for TP-Link UB500

### DIFF
--- a/custom/0001-rga3_uncompact_fix.patch
+++ b/custom/0001-rga3_uncompact_fix.patch
@@ -1,0 +1,22 @@
+diff --git a/drivers/video/rockchip/rga3/rga3_reg_info.c b/drivers/video/rockchip/rga3/rga3_reg_info.c
+index f6e4345..84388f3 100644
+--- a/drivers/video/rockchip/rga3/rga3_reg_info.c
++++ b/drivers/video/rockchip/rga3/rga3_reg_info.c
+@@ -331,7 +331,7 @@
+ 		 (s_RGA3_WIN0_RD_CTRL_SW_WIN0_YUV10B_COMPACT(1)));
+ 
+ 	/* Only on raster mode, yuv 10bit can change to compact or set endian */
+-	if (msg->win0.rd_mode == RGA_RASTER_MODE && yuv10 == 1) {
++	if (msg->win0.rd_mode == 0 && yuv10 == 1) {
+ 		reg =
+ 			((reg & (~m_RGA3_WIN0_RD_CTRL_SW_WIN0_YUV10B_COMPACT)) |
+ 			 (s_RGA3_WIN0_RD_CTRL_SW_WIN0_YUV10B_COMPACT
+@@ -703,7 +703,7 @@
+ 		 (s_RGA3_WIN1_RD_CTRL_SW_WIN1_YUV10B_COMPACT(1)));
+ 
+ 	/* Only on roster mode, yuv 10bit can change to compact or set endian */
+-	if (msg->win1.rd_mode == RGA_RASTER_MODE && yuv10 == 1) {
++	if (msg->win1.rd_mode == 0 && yuv10 == 1) {
+ 		reg =
+ 			((reg & (~m_RGA3_WIN1_RD_CTRL_SW_WIN1_YUV10B_COMPACT)) |
+ 			 (s_RGA3_WIN1_RD_CTRL_SW_WIN1_YUV10B_COMPACT

--- a/custom/0002-vop2_rgba2101010_capability_fix.patch
+++ b/custom/0002-vop2_rgba2101010_capability_fix.patch
@@ -1,0 +1,27 @@
+From dd8ba855bca010e281e3d69fb10c8a6600c4f541 Mon Sep 17 00:00:00 2001
+From: boogie <boogiepop@gmx.com>
+Date: Mon, 22 Jan 2024 12:00:42 +0100
+Subject: [PATCH] vop2 rbga2101010 capability fix
+
+---
+ drivers/gpu/drm/rockchip/rockchip_vop2_reg.c | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/drivers/gpu/drm/rockchip/rockchip_vop2_reg.c b/drivers/gpu/drm/rockchip/rockchip_vop2_reg.c
+index 31069d9aebf8..a12670e1c2e7 100644
+--- a/drivers/gpu/drm/rockchip/rockchip_vop2_reg.c
++++ b/drivers/gpu/drm/rockchip/rockchip_vop2_reg.c
+@@ -31,10 +31,6 @@
+ 		_VOP_REG(off, _mask, s, true)
+ 
+ static const uint32_t formats_for_cluster[] = {
+-	DRM_FORMAT_XRGB2101010,
+-	DRM_FORMAT_ARGB2101010,
+-	DRM_FORMAT_XBGR2101010,
+-	DRM_FORMAT_ABGR2101010,
+ 	DRM_FORMAT_XRGB8888,
+ 	DRM_FORMAT_ARGB8888,
+ 	DRM_FORMAT_XBGR8888,
+-- 
+2.43.0
+

--- a/custom/0003-tp_link_ub500.patch
+++ b/custom/0003-tp_link_ub500.patch
@@ -1,0 +1,13 @@
+--- a/drivers/bluetooth/btusb.c	2024-04-10 13:53:16.722911588 +0300
++++ b/drivers/bluetooth/btusb.c	2024-04-10 13:57:11.010704352 +0300
+@@ -452,6 +452,10 @@
+ 	{ USB_DEVICE(0x0bda, 0xb009), .driver_info = BTUSB_REALTEK },
+ 	{ USB_DEVICE(0x2ff8, 0xb011), .driver_info = BTUSB_REALTEK },
+ 
++	/* Additional Realtek 8761B Bluetooth devices */
++	{ USB_DEVICE(0x2357, 0x0604), .driver_info = BTUSB_REALTEK |
++						     BTUSB_WIDEBAND_SPEECH },
++
+ 	/* Additional Realtek 8821AE Bluetooth devices */
+ 	{ USB_DEVICE(0x0b05, 0x17dc), .driver_info = BTUSB_REALTEK },
+ 	{ USB_DEVICE(0x13d3, 0x3414), .driver_info = BTUSB_REALTEK },


### PR DESCRIPTION
Closes https://github.com/7Ji-PKGBUILDs/.meta/issues/31

This PR adds patches for rockchip vop2 & rga bugs (see more discussion in the linked issue).

I'm also carrying around this patch that adds support for TP-Link UB500 bluetooth adapter. It's available since kernel > 5.16, and this is just a backport of this patch to 5.10.